### PR TITLE
Save all logos as Plain SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Linux Mint Logo and brand resources
 | High Badge  | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/high-badge-mono.svg" height="150"> | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/high-badge.svg" height="150"> |
 | Leaf  | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/leaf-mono.svg" height="150"> | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/leaf.svg" height="150"> |
 | Leaf Badge  | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/leaf-badge-mono.svg" height="150"> | <img src="https://raw.githubusercontent.com/linuxmint/brand-logo/master/leaf-badge.svg" height="150"> |
+
+<br />
+### Save as Plain SVG and use pixels (px) as units
+All these files are saved as plain SVG (Inkscape > File > Save As... Plain SVG). This makes the files smaller without loosing any important data. Except one information: all units are in pixels. Everything was made using round numbers here. There is no such thing as `x=1.234 px` anywhere here. Prior to doing any edit, please set your document and tool units to pixels and use only round numbers.

--- a/badge-mono.svg
+++ b/badge-mono.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview

--- a/badge-mono.svg
+++ b/badge-mono.svg
@@ -7,64 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="badge-mono.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="30.25"
-     inkscape:cy="127.75"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0"
-     borderlayer="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="12"
-       spacingy="12"
-       empspacing="2"
-       originx="44"
-       originy="38"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        id="path40"
        style="fill:#505050;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1"

--- a/badge.svg
+++ b/badge.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -79,13 +77,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata153">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/badge.svg
+++ b/badge.svg
@@ -7,64 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="badge.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0"
-     borderlayer="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="12"
-       spacingy="12"
-       empspacing="2"
-       originx="44"
-       originy="38"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <circle
        style="fill:#86be43;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
        id="path40"
@@ -74,7 +22,6 @@
     <path
        style="color:#000000;fill:#505050;stroke-width:0;-inkscape-stroke:none"
        d="m 44.00001,50.00001 v 108 c 0,26.3675 21.63249,48 48,48 h 72 c 26.3675,0 48,-21.6325 48,-48 v -60 c 0,-19.7401 -16.25991,-36 -36,-36 -9.22193,0 -17.60014,3.64514 -24,9.43946 -6.39986,-5.79432 -14.77808,-9.43946 -24,-9.43946 -19.7401,0 -36,16.2599 -36,36 v 60 h 24 v -60 c 0,-6.76954 5.23046,-12 12,-12 6.76953,0 12,5.23046 12,12 v 60 h 24 v -60 c 0,-6.76954 5.23046,-12 12,-12 6.76953,0 12,5.23046 12,12 v 60 c 0,13.39696 -10.60304,24 -24,24 h -72 c -13.39697,0 -24,-10.60304 -24,-24 v -108 z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/high-badge-mono.svg
+++ b/high-badge-mono.svg
@@ -7,64 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="high-badge-mono.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0"
-     borderlayer="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="13"
-       spacingy="13"
-       empspacing="2"
-       originx="37"
-       originy="210"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        id="path40"
        style="fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"

--- a/high-badge-mono.svg
+++ b/high-badge-mono.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -72,13 +70,4 @@
        style="fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
        d="M 128,0 A 128,128 0 0 0 63.000002,17.816402 V 158 c 0,14.51337 11.48662,26 26,26 H 167 c 14.51337,0 26,-11.48663 26,-26 V 93.000002 c 0,-7.33367 -5.66634,-13 -13,-13 -7.33367,0 -13,5.66633 -13,13 V 158 H 141 V 93.000002 c 0,-7.33367 -5.66634,-13 -13,-13 -7.33367,0 -13,5.66633 -13,13 V 158 H 89.000002 V 93.000002 c 0,-21.38511 17.614888,-39 38.999998,-39 9.99041,0 19.06682,3.94938 26,10.22656 6.93318,-6.27718 16.00958,-10.22656 26,-10.22656 21.3851,0 39,17.61489 39,39 V 158 c 0,28.56479 -23.43521,52 -52,52 H 89.000002 c -28.5648,0 -52,-23.43521 -52,-52 V 38.048832 A 128,128 0 0 0 0,128 128,128 0 0 0 128,256 128,128 0 0 0 256,128 128,128 0 0 0 128,0 Z" />
   </g>
-  <metadata
-     id="metadata37">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/high-badge.svg
+++ b/high-badge.svg
@@ -7,64 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="high-badge.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="127.75"
-     inkscape:cy="127.75"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0"
-     borderlayer="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="13"
-       spacingy="13"
-       empspacing="2"
-       originx="37"
-       originy="210"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <circle
        style="fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
        id="circle553"

--- a/high-badge.svg
+++ b/high-badge.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -78,13 +76,4 @@
        style="fill:#86be43;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
        d="M 128,0 A 128,128 0 0 0 63,17.816406 V 158 c 0,14.51337 11.48662,26 26,26 h 78 c 14.51337,0 26,-11.48663 26,-26 V 93 c 0,-7.33367 -5.66634,-13 -13,-13 -7.33367,0 -13,5.66633 -13,13 v 65 H 141 V 93 c 0,-7.33367 -5.66634,-13 -13,-13 -7.33367,0 -13,5.66633 -13,13 v 65 H 89 V 93 c 0,-21.38511 17.61489,-39 39,-39 9.99041,0 19.06682,3.949383 26,10.226562 C 160.93318,57.949382 170.00958,54 180,54 c 21.3851,0 39,17.61489 39,39 v 65 c 0,28.56479 -23.43521,52 -52,52 H 89 C 60.4352,210 37,186.56479 37,158 V 38.048828 A 128,128 0 0 0 0,128 128,128 0 0 0 128,256 128,128 0 0 0 256,128 128,128 0 0 0 128,0 Z" />
   </g>
-  <metadata
-     id="metadata28">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/leaf-badge-mono.svg
+++ b/leaf-badge-mono.svg
@@ -7,42 +7,15 @@
    viewBox="0 0 256 256"
    version="1.1"
    id="svg8"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="leaf-badge-mono.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1355"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <path
        style="opacity:1;fill:#505050;fill-opacity:1;stroke:none;stroke-width:0.996786;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M -1.1093753e-7,13.2498 V 86.62494 H 30.182337 v 14.72395 l 0.04162,57.75008 c 0,47.56146 41.312662,83.65123 88.916793,83.65123 H 256 V 97.58338 c 0,-47.6042 -41.26989,-83.64601 -88.91677,-83.64601 l -39.81256,-0.0907 z M 66.854238,55.70297 H 89.192802 V 156.224 c 0,12.469 9.869511,22.33852 22.338598,22.33852 h 67.01048 c 12.46907,0 22.33859,-9.86952 22.33859,-22.33852 v -55.84388 c 0,-6.30062 -4.86602,-11.17187 -11.16669,-11.17187 -6.30069,0 -11.1719,4.87125 -11.1719,11.17187 V 156.224 h -22.33857 v -55.84388 c 0,-6.30062 -4.866,-11.17187 -11.16668,-11.17187 -6.30067,0 -11.16668,4.87125 -11.16668,11.17187 V 156.224 H 111.5314 v -55.84388 c 0,-18.37285 15.13235,-33.50517 33.50523,-33.50517 8.58321,0 16.38196,3.38827 22.33856,8.7812 5.95663,-5.39293 13.75538,-8.7812 22.33859,-8.7812 18.37288,0 33.50524,15.13232 33.50524,33.50517 V 156.224 c 0,24.54123 -20.13587,44.67715 -44.67714,44.67715 H 111.5314 c -24.541291,0 -44.677162,-20.13592 -44.677162,-44.67715 z"
-       id="rect1013"
-       inkscape:connector-curvature="0" />
+       id="rect1013" />
   </g>
 </svg>

--- a/leaf-badge.svg
+++ b/leaf-badge.svg
@@ -7,37 +7,11 @@
    viewBox="0 0 256 256"
    version="1.1"
    id="svg8"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="leaf-badge.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="g1214"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1355"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <g
        id="g1214"
@@ -50,18 +24,15 @@
            id="rect1013-2"
            transform="scale(0.26458333)"
            d="m 414.36914,788.04883 v 48.05664 h 19.76953 V 845.75 l 0.0254,37.82422 c 0,31.15105 27.05922,54.78906 58.23828,54.78906 h 89.63672 V 843.2832 c 0,-31.17906 -27.02926,-54.78515 -58.23633,-54.78515 l -26.07617,-0.0586 z"
-           style="opacity:1;fill:#87cf3e;fill-opacity:1;stroke:none;stroke-width:0.652859;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           inkscape:connector-curvature="0" />
+           style="opacity:1;fill:#87cf3e;fill-opacity:1;stroke:none;stroke-width:0.652859;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <g
            id="layer3-2-3-6"
-           inkscape:label="Layer 1"
            transform="matrix(0.12154991,0,0,0.12154991,111.42789,203.16749)"
            style="stroke-width:0.0992187">
           <path
              style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#505050;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-             id="path4193-6-7-1"
-             inkscape:connector-curvature="0" />
+             id="path4193-6-7-1" />
         </g>
       </g>
     </g>

--- a/leaf-mono.svg
+++ b/leaf-mono.svg
@@ -7,37 +7,11 @@
    viewBox="0 0 256 256"
    version="1.1"
    id="svg8"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="leaf-mono.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1355"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <g
        id="g1068"
@@ -48,8 +22,6 @@
          transform="matrix(0.22163909,0,0,0.22163909,-7.7510456,130.86817)"
          id="g4676">
         <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccccccccccsccccc"
            d="m 170.64172,390.24714 c -36.45889,0 -68.09809,-27.63927 -68.09809,-64.06549 l -0.0327,-44.22927 V 270.67393 H 79.39629 v -56.19662 l 97.47493,0.45904 30.49168,0.0656 c 36.49165,0 68.09809,27.60639 68.09809,64.0653 V 390.24713 H 170.64178 v 0 0 z m 89.96675,-29.82397 c 0,-24.22032 0,-81.35591 0,-81.35591 0,-27.18003 -23.83589,-49.21283 -53.24561,-49.21283 h -30.52444 v -0.0656 L 94.28144,229.4281 v 26.39336 c 0,0 3.3159,0 9.24803,0 6.27863,0 13.83376,5.90029 13.83376,14.55878 l 0.0656,55.76887 c 0,27.18005 23.836,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43528,-5.88872 17.43528,-14.93876 z"
            style="display:inline;overflow:visible;visibility:visible;fill:#505050;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.111832;marker:none;enable-background:accumulate"
            id="path4210-8-3-3" />
@@ -57,13 +29,11 @@
       <g
          style="fill:#505050;fill-opacity:1;stroke-width:0.0992187"
          id="layer3-2-5-2-5"
-         inkscape:label="Layer 1"
          transform="matrix(0.11356117,0,0,0.11356117,12.684076,174.29676)">
         <path
            style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#505050;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           id="path4193-6-9-2-6"
-           inkscape:connector-curvature="0" />
+           id="path4193-6-9-2-6" />
       </g>
     </g>
   </g>

--- a/leaf.svg
+++ b/leaf.svg
@@ -7,37 +7,11 @@
    viewBox="0 0 256 256"
    version="1.1"
    id="svg8"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="leaf.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="g1108"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1415"
-     inkscape:window-x="2560"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <g
        id="g1108"
@@ -56,12 +30,8 @@
             <path
                style="display:inline;opacity:1;fill:#87cf3e;fill-opacity:1;fill-rule:evenodd;stroke-width:0.111832"
                d="m 671.90956,642.97352 c 0,-25.20809 0,-84.67388 0,-84.67388 0,-28.28854 -24.808,-51.21991 -55.41715,-51.21991 h -31.76933 v -0.0683 L 498.79913,506.636 v 30.8947 c 0,0 7.01578,0 13.18985,0 9.20682,0 10.8333,6.35563 10.8333,15.15255 l 0.0683,54.61836 c 0,28.28856 24.8081,51.21988 55.38309,51.21988 h 75.48956 c 9.67782,0 18.14635,-6.12887 18.14635,-15.548 z"
-               id="path2576-0-3-7-4-8"
-               sodipodi:nodetypes="cccccccsccccc"
-               inkscape:connector-curvature="0" />
+               id="path2576-0-3-7-4-8" />
             <path
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="ccccccccccccccccccccsccccc"
                d="m 577.77171,670.2471 c -36.45888,0 -68.09808,-27.63927 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19662 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82397 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18004 -23.83588,-49.21283 -53.2456,-49.21283 h -30.52444 v -0.0656 l -82.55696,-0.36074 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.55879 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88872 17.43527,-14.93876 z"
                style="display:inline;overflow:visible;visibility:visible;fill:#505050;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.111832;marker:none;enable-background:accumulate"
                id="path4210-8-6-5-7-3" />
@@ -70,13 +40,11 @@
         <g
            style="fill:#505050;fill-opacity:1;stroke-width:0.0992187"
            id="layer3-2-5-2-2"
-           inkscape:label="Layer 1"
            transform="matrix(0.27212591,0,0,0.27212591,-37.922389,261.72722)">
           <path
              style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#505050;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
              d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-             id="path4193-6-9-2-91"
-             inkscape:connector-curvature="0" />
+             id="path4193-6-9-2-91" />
         </g>
       </g>
     </g>

--- a/ring-mono.svg
+++ b/ring-mono.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -78,13 +76,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata172">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/ring-mono.svg
+++ b/ring-mono.svg
@@ -7,63 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="ring-mono.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="10"
-       spacingy="10"
-       empspacing="2"
-       originx="58"
-       originy="53"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <circle
        style="fill:none;fill-opacity:1;stroke:#505050;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path32"
@@ -73,7 +22,6 @@
     <path
        style="color:#000000;fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;-inkscape-stroke:none"
        d="m 58.000005,63.000005 v 90.000005 c 0,21.97292 18.02708,40 40,40 h 60.000005 c 21.97292,0 40,-18.02708 40,-40 v -50 c 0,-16.450085 -13.54992,-30.000005 -30,-30.000005 -7.68494,0 -14.66678,3.03762 -20,7.86622 -5.33322,-4.8286 -12.31506,-7.86622 -20,-7.86622 -16.45008,0 -30.000005,13.54992 -30.000005,30.000005 v 50 h 20.000005 v -50 c 0,-5.641285 4.35872,-10.000005 10,-10.000005 5.64128,0 10,4.35872 10,10.000005 v 50 h 20 v -50 c 0,-5.641285 4.35872,-10.000005 10,-10.000005 5.64128,0 10,4.35872 10,10.000005 v 50 c 0,11.16414 -8.83586,20 -20,20 H 98.000005 c -11.16414,0 -20,-8.83586 -20,-20 V 63.000005 Z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/ring.svg
+++ b/ring.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -78,13 +76,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata130">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/ring.svg
+++ b/ring.svg
@@ -7,63 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="ring.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="false"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="10"
-       spacingy="10"
-       empspacing="2"
-       originx="58"
-       originy="53"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <circle
        style="fill:#86be43;fill-opacity:1;stroke:#505050;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path32"
@@ -73,7 +22,6 @@
     <path
        style="color:#000000;fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;-inkscape-stroke:none"
        d="m 58.000005,63.000005 v 90.000005 c 0,21.97292 18.02708,40 40,40 h 60.000005 c 21.97292,0 40,-18.02708 40,-40 v -50 c 0,-16.450085 -13.54992,-30.000005 -30,-30.000005 -7.68494,0 -14.66678,3.03762 -20,7.86622 -5.33322,-4.8286 -12.31506,-7.86622 -20,-7.86622 -16.45008,0 -30.000005,13.54992 -30.000005,30.000005 v 50 h 20.000005 v -50 c 0,-5.641285 4.35872,-10.000005 10,-10.000005 5.64128,0 10,4.35872 10,10.000005 v 50 h 20 v -50 c 0,-5.641285 4.35872,-10.000005 10,-10.000005 5.64128,0 10,4.35872 10,10.000005 v 50 c 0,11.16414 -8.83586,20 -20,20 H 98.000005 c -11.16414,0 -20,-8.83586 -20,-20 V 63.000005 Z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/simple-mono.svg
+++ b/simple-mono.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -72,13 +70,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata149">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/simple-mono.svg
+++ b/simple-mono.svg
@@ -7,67 +7,15 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="simple-mono.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="18"
-       spacingy="18"
-       empspacing="2"
-       originx="2"
-       originy="29"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        style="color:#000000;fill:#505050;fill-opacity:1;stroke:none;stroke-width:0;-inkscape-stroke:none"
        d="m 2,11 v 162 c 0,39.55126 32.44874,72 72,72 h 108 c 39.55126,0 72,-32.44874 72,-72 V 83 C 254,53.38986 229.61014,29 200,29 186.16711,29 173.5998,34.46772 164,43.1592 154.4002,34.46772 141.83289,29 128,29 98.38986,29 74,53.38986 74,83 v 90 h 36 V 83 c 0,-10.1543 7.8457,-18 18,-18 10.1543,0 18,7.8457 18,18 v 90 h 36 V 83 c 0,-10.1543 7.8457,-18 18,-18 10.1543,0 18,7.8457 18,18 v 90 c 0,20.09545 -15.90455,36 -36,36 H 74 C 53.90455,209 38,193.09545 38,173 V 11 Z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/sources/1-origin-stroke.svg
+++ b/sources/1-origin-stroke.svg
@@ -7,63 +7,12 @@
    viewBox="0 0 140 140"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="1-origin-stroke.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-265.5"
-     inkscape:cy="69.5"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="10"
-       spacingy="10"
-       empspacing="2"
-       originx="0"
-       originy="0"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        id="path4193"
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:20;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"

--- a/sources/1-origin-stroke.svg
+++ b/sources/1-origin-stroke.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -28,10 +26,10 @@
      pagecolor="#c0c0c0"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageopacity="1"
+     inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="69.5"
+     inkscape:cx="-265.5"
      inkscape:cy="69.5"
      inkscape:document-units="px"
      inkscape:current-layer="layer3"
@@ -71,13 +69,4 @@
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:20;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 90,50 C 90,38.95431 81.04569,30 70,30 58.95431,30 50,38.95431 50,50 v 50 M 10,0 v 100 c 0,16.56854 13.43146,30 30,30 20,0 40,0 60,0 16.56854,0 30,-13.43146 30,-30 V 50 C 130,38.95431 121.04569,30 110,30 98.95431,30 90,38.95431 90,50 v 50" />
   </g>
-  <metadata
-     id="metadata37">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/sources/2-origin-path.svg
+++ b/sources/2-origin-path.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -71,13 +69,4 @@
        d="m 0,0 v 100 c 0,21.97292 18.02708,40 40,40 h 60 c 21.97292,0 40,-18.02708 40,-40 V 50 C 140,33.54992 126.45008,20 110,20 102.31506,20 95.33322,23.03762 90,27.86622 84.66678,23.03762 77.68494,20 70,20 53.54992,20 40,33.54992 40,50 v 50 H 60 V 50 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 h 20 V 50 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 c 0,11.16414 -8.83586,20 -20,20 H 40 C 28.83586,120 20,111.16414 20,100 V 0 Z"
        id="path4193" />
   </g>
-  <metadata
-     id="metadata16">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/sources/2-origin-path.svg
+++ b/sources/2-origin-path.svg
@@ -7,63 +7,12 @@
    viewBox="0 0 140 140"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="2-origin-path.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.2357143"
-     inkscape:cx="70"
-     inkscape:cy="70"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="10"
-       spacingy="10"
-       empspacing="2"
-       originx="0"
-       originy="0"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        style="color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;-inkscape-stroke:none"
        d="m 0,0 v 100 c 0,21.97292 18.02708,40 40,40 h 60 c 21.97292,0 40,-18.02708 40,-40 V 50 C 140,33.54992 126.45008,20 110,20 102.31506,20 95.33322,23.03762 90,27.86622 84.66678,23.03762 77.68494,20 70,20 53.54992,20 40,33.54992 40,50 v 50 H 60 V 50 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 h 20 V 50 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 c 0,11.16414 -8.83586,20 -20,20 H 40 C 28.83586,120 20,111.16414 20,100 V 0 Z"

--- a/sources/3-origin-path-low.svg
+++ b/sources/3-origin-path-low.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -72,13 +70,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata25">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>

--- a/sources/3-origin-path-low.svg
+++ b/sources/3-origin-path-low.svg
@@ -7,67 +7,15 @@
    viewBox="0 0 140 130"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="3-origin-path-low.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.7153846"
-     inkscape:cx="70.063001"
-     inkscape:cy="65"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="10"
-       spacingy="10"
-       empspacing="2"
-       originx="0"
-       originy="10"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <path
        style="color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0;-inkscape-stroke:none"
        d="m 0,0 v 90 c 0,21.97292 18.02708,40 40,40 h 60 c 21.97292,0 40,-18.02708 40,-40 V 40 C 140,23.54992 126.45008,10 110,10 102.31506,10 95.33322,13.03762 90,17.86622 84.66678,13.03762 77.68494,10 70,10 53.54992,10 40,23.54992 40,40 V 90 H 60 V 40 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 h 20 V 40 c 0,-5.64128 4.35872,-10 10,-10 5.64128,0 10,4.35872 10,10 v 50 c 0,11.16414 -8.83586,20 -20,20 H 40 C 28.83586,110 20,101.16414 20,90 V 0 Z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/sources/high-badge-src.svg
+++ b/sources/high-badge-src.svg
@@ -7,64 +7,12 @@
    viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
-   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
-   sodipodi:docname="high-badge-src.svg"
-   inkscape:export-filename="/home/sebastien/Sources/LinuxMint-logo-Y/LM-logo-Y-01b(singleline).png"
-   inkscape:export-xdpi="180"
-   inkscape:export-ydpi="180"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
   <defs
      id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#c0c0c0"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="1"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.4101562"
-     inkscape:cx="128"
-     inkscape:cy="128"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="true"
-     inkscape:window-width="506"
-     inkscape:window-height="546"
-     inkscape:window-x="512"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     units="px"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     inkscape:pagecheckerboard="0"
-     borderlayer="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4139"
-       spacingx="13"
-       spacingy="13"
-       empspacing="2"
-       originx="37"
-       originy="210"
-       empcolor="#ff3f3f"
-       empopacity="0.25098039" />
-  </sodipodi:namedview>
   <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 1">
+     id="layer3">
     <circle
        style="fill:#86be43;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
        id="path40"
@@ -74,7 +22,6 @@
     <path
        style="color:#000000;fill:#505050;stroke-width:0;-inkscape-stroke:none"
        d="M 37.00001,8e-6 V 158.00001 c 0,28.56479 23.4352,52 52,52 h 78 c 28.56479,0 52,-23.43521 52,-52 v -65 c 0,-21.38511 -17.6149,-39 -39,-39 -9.99042,0 -19.06682,3.9489 -26,10.22608 -6.93318,-6.27718 -16.00959,-10.22608 -26,-10.22608 -21.38511,0 -39,17.61489 -39,39 v 65 h 26 v -65 c 0,-7.33367 5.66633,-13 13,-13 7.33366,0 13,5.66633 13,13 v 65 h 26 v -65 c 0,-7.33367 5.66633,-13 13,-13 7.33366,0 13,5.66633 13,13 v 65 c 0,14.51337 -11.48663,26 -26,26 h -78 c -14.51338,0 -26,-11.48663 -26,-26 V 8e-6 Z"
-       id="path4193"
-       sodipodi:nodetypes="csssssscssccsssccssssssscc" />
+       id="path4193" />
   </g>
 </svg>

--- a/sources/high-badge-src.svg
+++ b/sources/high-badge-src.svg
@@ -19,8 +19,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title
-     id="title3343">Linux Mint logo</title>
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -79,13 +77,4 @@
        id="path4193"
        sodipodi:nodetypes="csssssscssccsssccssssssscc" />
   </g>
-  <metadata
-     id="metadata35">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Linux Mint logo</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
 </svg>


### PR DESCRIPTION
* Xed edit all files (DELETE <title> elements causing new metadata to be generated)
* Save all files as Plain SVG (making files smaller, stripped from useless information)
* README.md "Save as Plain SVG and use pixels (px) as units"